### PR TITLE
Fix reduce macro usage documentation

### DIFF
--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -120,15 +120,15 @@ implementation.
 
 CEL provides built-in **macros** for reducing boilerplate expressions:
 
-| Macro                           | Description                                                                              | Example                                      |
-|---------------------------------|------------------------------------------------------------------------------------------|----------------------------------------------|
-| `has(field)`                    | Checks if a field exists                                                                 | `has(resource.owner)`                        |
-| `all(list, x, cond)`            | Returns `true` if all elements match a condition                                         | `[1, 2, 3].all(x, x > 0)`                    |
-| `exists(list, x, cond)`         | Returns `true` if any element matches a condition                                        | `[1, 2, 3].exists(x, x == 2)`                |
-| `exists_one(list, x, cond)`     | Returns `true` if exactly one element matches a condition                                | `[1, 2, 3].exists_one(x, x == 2)`            |
-| `filter(list, x, cond)`         | Returns a list of elements matching a condition                                          | `[1, 2, 3, 4].filter(x, x > 2)`              |
-| `map(list, x, expr)`            | Transforms list elements using an expression                                             | `[1, 2, 3].map(x, x * 2)`                    |
-| `reduce(list, acc, x, op_expr)` | Iterates over list, applying expr to accumulate a value acc (initial accumulator value). | `[1, 2, 3, 4].reduce(0, x, acc + x)` -> `10` |
+| Macro                                     | Description                                                                                      | Example                                           |
+|-------------------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| `has(field)`                              | Checks if a field exists                                                                         | `has(resource.owner)`                             |
+| `all(list, x, cond)`                      | Returns `true` if all elements match a condition                                                 | `[1, 2, 3].all(x, x > 0)`                         |
+| `exists(list, x, cond)`                   | Returns `true` if any element matches a condition                                                | `[1, 2, 3].exists(x, x == 2)`                     |
+| `exists_one(list, x, cond)`               | Returns `true` if exactly one element matches a condition                                        | `[1, 2, 3].exists_one(x, x == 2)`                 |
+| `filter(list, x, cond)`                   | Returns a list of elements matching a condition                                                  | `[1, 2, 3, 4].filter(x, x > 2)`                   |
+| `map(list, x, expr)`                      | Transforms list elements using an expression                                                     | `[1, 2, 3].map(x, x * 2)`                         |
+| `reduce(list, acc, x, init_acc, op_expr)` | Iterates over list, applying `op_expr` to accumulate a value `acc` (initially set to `init_acc`) | `[1, 2, 3, 4].reduce(acc, x, 0, acc + x)` -> `10` |
 
 ### Extensions
 


### PR DESCRIPTION
Documentation missed the initial value parameter. Had to track down the Python CEL implementation source to figure out why I was seeing errors.

Side note, the error message presented when the parameter is missing isn't very helpful in diagnosing what's wrong:

i.e., `[1, 2, 3, 4].reduce(0, x, x + acc)`, as written in the original documentation, leads to:
`Failures: Unknown pop from empty list.`